### PR TITLE
Correct k9s release asset name

### DIFF
--- a/kubernetes/core.yaml
+++ b/kubernetes/core.yaml
@@ -57,7 +57,7 @@
       become: yes
       unarchive:
         remote_src: yes
-        src: https://github.com/derailed/k9s/releases/download/{{ k9s_version.stdout }}/k9s_{{ k9s_version.stdout }}_Linux_x86_64.tar.gz
+        src: https://github.com/derailed/k9s/releases/download/{{ k9s_version.stdout }}/k9s_Linux_x86_64.tar.gz
         dest: /opt/derailed/k9s/{{ k9s_version.stdout }}
         creates: /opt/derailed/k9s/{{ k9s_version.stdout }}/k9s
       when: not is_mac


### PR DESCRIPTION
Recently while using my fork to set up my freshly-installed Pop!_OS machine, I noticed that the k9s project seems to have changed their release asset names ([see here](https://github.com/derailed/k9s/releases/tag/v0.24.14) for an example). This PR corrects that name!